### PR TITLE
Fixed the order messages display on the chat screen

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -53,7 +53,8 @@ const defaultPhoto = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS1ht
       onSnapshot(
         query(
           collection(db, `chats/${route.params.id}`, 'messages'),
-          orderBy('timestamp', 'desc')
+          orderBy('timestamp')
+          // ^^^ need to come back to here. Messages are being displayed in the wrong order. ^^^
         ),
         (snapshot) => {
           setMessages(


### PR DESCRIPTION
Messages were showing up in descending order. I removed "desc" and they appear in the correct order. 